### PR TITLE
IO: use Location, TypedIOService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@ Wisconsin-Madison, and Friedrich Miescher Institute for Biomedical Research.</li
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
+		<scijava-common.version>2.84.0</scijava-common.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/scijava/table/io/ColumnTableIOOptions.java
+++ b/src/main/java/org/scijava/table/io/ColumnTableIOOptions.java
@@ -47,7 +47,7 @@ public class ColumnTableIOOptions extends AbstractOptions<ColumnTableIOOptions> 
 		return setValue(formatterKey, formatter);
 	}
 
-	ColumnTableIOOptions parser(Function<String, Object> parser) {
+	ColumnTableIOOptions parser(Function<String, ?> parser) {
 		return setValue(parserKey, parser);
 	}
 
@@ -57,7 +57,7 @@ public class ColumnTableIOOptions extends AbstractOptions<ColumnTableIOOptions> 
 			return getValueOrDefault(formatterKey, String::valueOf);
 		}
 
-		public Function<String, Object> parser() {
+		public Function<String, ?> parser() {
 			return getValueOrDefault(parserKey, String::valueOf);
 		}
 	}

--- a/src/main/java/org/scijava/table/io/TableIOOptions.java
+++ b/src/main/java/org/scijava/table/io/TableIOOptions.java
@@ -135,7 +135,7 @@ public class TableIOOptions extends AbstractOptions<TableIOOptions> {
 	/**
 	 * @param parser Parser to use when converting table entries into data objects.
 	 */
-	public TableIOOptions parser(Function<String, Object> parser) {
+	public TableIOOptions parser(Function<String, ?> parser) {
 		guessParser(false);
 		return setValue(parserKey, parser);
 	}
@@ -188,7 +188,7 @@ public class TableIOOptions extends AbstractOptions<TableIOOptions> {
 		return this;
 	}
 
-	private Function<String, Object> getParser(Class<?> type) {
+	private Function<String, ?> getParser(Class<?> type) {
 		if(type.equals(String.class)) return String::valueOf;
 		if(type.equals(Double.class)) return Double::valueOf;
 		if(type.equals(Float.class)) return Float::valueOf;
@@ -266,7 +266,7 @@ public class TableIOOptions extends AbstractOptions<TableIOOptions> {
 		/**
 		 * @return Parser to use when converting table entries into data objects.
 		 */
-		public Function<String, Object> parser() {
+		public Function<String, ?> parser() {
 			return getValueOrDefault(parserKey, String::valueOf);
 		}
 

--- a/src/main/java/org/scijava/table/io/TableIOPlugin.java
+++ b/src/main/java/org/scijava/table/io/TableIOPlugin.java
@@ -30,7 +30,8 @@
 
 package org.scijava.table.io;
 
-import org.scijava.io.AbstractIOPlugin;
+import org.scijava.io.IOPlugin;
+import org.scijava.io.location.Location;
 import org.scijava.table.Table;
 
 import java.io.IOException;
@@ -40,32 +41,30 @@ import java.io.IOException;
  *
  * @author Deborah Schmidt
  */
-public class TableIOPlugin extends AbstractIOPlugin<Table> {
+public interface TableIOPlugin extends IOPlugin<Table> {
 
 	@Override
-	public Table<?, ?> open(String source) throws IOException {
+	default Table<?, ?> open(Location source) throws IOException {
 		return open(source, new TableIOOptions());
 	}
 
 	/** Opens data from the given source. */
-	@SuppressWarnings("unused")
-	public Table<?, ?> open(final String source, final TableIOOptions options) throws IOException {
+	default Table<?, ?> open(final Location source, final TableIOOptions options) throws IOException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public void save(Table data, String destination) throws IOException {
+	default void save(Table data, Location destination) throws IOException {
 		save(data, destination, new TableIOOptions());
 	}
 
 	/** Saves the given data to the specified destination. */
-	@SuppressWarnings("unused")
-	public void save(final Table<?, ?> data, final String destination, final TableIOOptions options) throws IOException {
+	default void save(final Table<?, ?> data, final Location destination, final TableIOOptions options) throws IOException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public Class<Table> getDataType() {
+	default Class<Table> getDataType() {
 		return Table.class;
 	}
 }

--- a/src/main/java/org/scijava/table/io/TableIOService.java
+++ b/src/main/java/org/scijava/table/io/TableIOService.java
@@ -32,18 +32,25 @@ package org.scijava.table.io;
 
 import java.io.IOException;
 
+import org.scijava.io.IOService;
+import org.scijava.io.TypedIOService;
+import org.scijava.io.location.Location;
 import org.scijava.service.SciJavaService;
 import org.scijava.table.Table;
 
-public interface TableIOService extends SciJavaService {
+public interface TableIOService extends TypedIOService<Table<?, ?>> {
 
-	boolean canOpen(String source);
-
-	boolean canSave(Table<?, ?> table, String destination);
-
-	Table<?, ?> open(String source) throws IOException;
+	@Override
+	default Table<?, ?> open(Location source) throws IOException {
+		return open(source, TableIOOptions.options());
+	}
 	Table<?, ?> open(String source, TableIOOptions options) throws IOException;
+	Table<?, ?> open(Location source, TableIOOptions options) throws IOException;
 
-	void save(Table<?, ?> table, String destination) throws IOException;
+	@Override
+	default void save(Table<?, ?> table, Location destination) throws IOException {
+		save(table, destination, TableIOOptions.options());
+	}
 	void save(Table<?, ?> table, String destination, TableIOOptions options) throws IOException;
+	void save(Table<?, ?> table, Location destination, TableIOOptions options) throws IOException;
 }

--- a/src/test/java/org/scijava/table/io/TableIOServiceTest.java
+++ b/src/test/java/org/scijava/table/io/TableIOServiceTest.java
@@ -34,7 +34,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.scijava.Context;
+import org.scijava.io.AbstractIOPlugin;
 import org.scijava.io.IOPlugin;
+import org.scijava.io.location.Location;
 import org.scijava.plugin.PluginInfo;
 import org.scijava.plugin.PluginService;
 import org.scijava.table.DefaultGenericTable;
@@ -107,16 +109,16 @@ public class TableIOServiceTest {
 	}
 
 	@SuppressWarnings("rawtypes")
-	public static class FakeTableIOPlugin extends TableIOPlugin {
+	public static class FakeTableIOPlugin extends AbstractIOPlugin<Table> implements TableIOPlugin {
 
 		@Override
-		public boolean supportsOpen(String loc) {
-			return loc.endsWith("fakeTable");
+		public boolean supportsOpen(Location loc) {
+			return loc.getName().endsWith("fakeTable");
 		}
 
 		@Override
-		public boolean supportsSave(String loc) {
-			return loc.endsWith("fakeTable");
+		public boolean supportsSave(Location loc) {
+			return loc.getName().endsWith("fakeTable");
 		}
 
 		/**
@@ -124,7 +126,7 @@ public class TableIOServiceTest {
 		 * It creates a row and a column with header names based on the {@param options}.
 		 */
 		@Override
-		public Table open(String loc, TableIOOptions options) {
+		public Table open(Location loc, TableIOOptions options) {
 			DefaultGenericTable table = new DefaultGenericTable();
 			if(options.values.readColumnHeaders()) {
 				table.appendColumn(String.valueOf(options.values.columnDelimiter()));


### PR DESCRIPTION
This PR depends on the following PRs in `scijava-common`:
- https://github.com/scijava/scijava-common/pull/395
- https://github.com/scijava/scijava-common/pull/396

It makes the IO classes to use `Location` and the `TypedIOService`. It also sneaks in a small change to the `TableIOOptions` where the parser is now of type `Function<String, ?>` instead of `Function<String, Object>`.